### PR TITLE
Remove Metal Multiplication

### DIFF
--- a/items_game.txt
+++ b/items_game.txt
@@ -1964,6 +1964,7 @@ Weapon from: New Old Weapons Pack"
 			"item_name"					"The Storage Backpack"
 			"item_type_name"			"Backpack"
 			"item_description"			"
+Adds 50 metal to your metal reserve
 Replaces your Shotgun
 You are unable to use a Primary Weapon while this item is equipped
 
@@ -1979,10 +1980,10 @@ Weapon from: New Old Weapons Pack"
 			"act_as_wearable"			"1"
 			"attributes"
 			{
-				"maxammo metal increased"														// 250 metal seems fair. 300 metal seemed like way too much.
+				"strange restriction type 1" //"maxammo metal increased"		// 250 metal seems fair. 300 metal seemed like way too much.
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.5"
+					"value"				"50"
 				}
 				"move speed penalty"															// So you can't bugger off as fast
 				{
@@ -3584,10 +3585,10 @@ Weapon from: New Old Weapons Pack" 														// Have to put it here, since n
 					"attribute_class"	"mod_ammo_per_shot"
 					"value"				"2"
 				}
-				"voice pitch scale"
+				"strange restriction type 1"
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.6" 
+					"value"				"75" 
 				}
 			}
 			"visuals"
@@ -13747,15 +13748,11 @@ Weapon by: 'Majro'"
 
 			"attributes"
 			{
-				"provide on active"
-				{
-					"attribute_class"	"provide_on_active"
-					"value" 			"1"
-				}	
-				"hidden secondary max ammo penalty"	//"maxammo primary increased" Christ almighty, it uses your ammo reserve as metal. Why?!
+	
+				"strange restriction type 1"	//"maxammo primary increased" Christ almighty, it uses your ammo reserve as metal. Why?!
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				6.25
+					"value"				"168"
 				}
 				
 				"mod ammo per shot" //So I have to load up 10 shots every time to shoot 10 shots.
@@ -15864,10 +15861,10 @@ Weapon from: Tangerine Paint and Grunt's Weapon Addons"
 //					"attribute_class"	"mult_reload_time"
 //					"value" 			"1.5"
 //				}
-				"voice pitch scale"
+				"strange restriction type 1"
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.6" 
+					"value"				"75" 
 				}
 			}
 			"visuals"
@@ -17853,6 +17850,7 @@ Modified by: 'Reagy'"
 			"item_name"					"PDA: Handy Partner"
 			"item_type_name"			"#TF_Weapon_PDA_Engineer"
 			"item_description"			"
+Adds 50 metal to your metal reserve
 Makes support buildings build faster and increases the Dispenser's range at the cost of reducing the Sentry's construction speed by 50%
 
 Weapon from: Tangerine Paint and Grunt's Weapon Addons"
@@ -17881,10 +17879,10 @@ Weapon from: Tangerine Paint and Grunt's Weapon Addons"
 					"attribute_class"	"teleporter_build_rate_multiplier"
 					"value"				"2.25"
 				}
-				"maxammo metal increased"								
+				"strange restriction type 1"								
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.25"
+					"value"				"75"
 				}
 				"maxammo primary reduced"								
 				{
@@ -20720,6 +20718,8 @@ Wearable from: Tangerine Paint and Grunt's Weapon Addons"
 			"item_type_name"			"Robot"
 			"item_name"				"Geared Up Ghost"
 			"item_description"			"
+Adds 50 metal to your metal reserve
+
 Eyes up, mercenary.
 
 Wearable from: Tangerine Paint and Grunt's Weapon Addons"
@@ -20743,10 +20743,10 @@ Wearable from: Tangerine Paint and Grunt's Weapon Addons"
 					"attribute_class"	"mult_maxammo_primary"
 					"value"				"1.5"
 				}
-				"maxammo metal increased"														// 250 metal seems fair. 300 metal seemed like way too much.
+				"strange restriction type 1"								
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.25"
+					"value"				"50"
 				}
 				"allowed in medieval mode"
 				{
@@ -23693,7 +23693,7 @@ This weapon has a higher random critical hit chance
 
 You die instantly to any critical hit and deal increased close range damage.
 
-Your maximum metal count is halved.
+Your maximum metal count is reduced by 100.
 
 Once found in an english river, powerful feelings of atonement manifest from the weapon.
 
@@ -23748,10 +23748,10 @@ Weapon by: 'The One Of Wonders'"
 					"attribute_class"	"mult_clipsize"
 					"value"				"0.66666666666" 
 				}
-				"voice pitch scale"
+				"strange restriction type 1"
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"0.5" 
+					"value"				"-100" 
 				}
 			}
 			"visuals"
@@ -25183,11 +25183,7 @@ Weapon by: 'The One Of Wonders'"
 			}
 			"attributes"
 			{
-			    "provide on active"
-				{
-					"attribute_class"	"provide_on_active"
-					"value" 			"1"
-				}	
+
 			    "crit mod disabled"															
 				{
 					"attribute_class"	"mult_crit_chance"
@@ -25223,10 +25219,10 @@ Weapon by: 'The One Of Wonders'"
 					"attribute_class"	"mod_use_metal_ammo_type"
 					"value"				"1"
 				}
-				"hidden secondary max ammo penalty"	
+				"strange restriction type 1"
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"1.6"
+					"value"				"75"
 				}
 				"scattergun no reload single"													
 				{
@@ -26697,6 +26693,7 @@ Weapon by: 'The One Of Wonders'"
 			"item_description"			"Buildings are upgraded faster and cost less to build
 
 Buildings have 20% less health
+Your metal count is reduced by 90
 
 Well, looks like I'm the real Engineer around here.
 
@@ -26752,10 +26749,10 @@ Weapon by: 'The One Of Wonders'"
 					"attribute_class"	"mult_construction_value"
 					"value"				"0.15"
 				}
-				"maxammo metal reduced"
+				"strange restriction type 1"
 				{
 					"attribute_class"	"mult_maxammo_metal"
-					"value"				"0.55"
+					"value"				"-90"
 				}
 				"voice pitch scale"
 				{


### PR DESCRIPTION
Hopefully not screwing up my first pull request, but I've changed all the weapons and utilities that multiply metal counts to simply add or subtract them instead.

Affected are:
The Storage Backpack
The Pneumatic Pulverizer
Big Mean Mother Hubbard
Texas Typewriter
The Handy Partner
The Geared Up Ghost (Engineer)
Broken Mann's Legacy
Tinkerer's Tetra-Shot
PDA: Hardware Specialist
