### PR TITLE
Hard-Hitting Hardware Rework Proposal

### DIFF
--- a/custom_items_game.txt
+++ b/custom_items_game.txt
@@ -25686,10 +25686,10 @@ Weapon by: 'The One Of Wonders'"
 			"used_by_classes"
 			{
 				"demoman"				"1"
-			}
+			}			
 			"attributes"																	
 			{
-		        "bleeding duration"												
+		        	"bleeding duration"												
 				{
 					"attribute_class"	"bleeding_duration"
 					"value" 			"2"
@@ -25702,8 +25702,9 @@ Weapon by: 'The One Of Wonders'"
 				"Fire rate bonus"
 				{
 					"attribute_class"	"mult_postfiredelay"
-					"value"				"0.9"
+					"value"				"0.75"
 				}
+				
 				"damage penalty"
 				{
 					"attribute_class"	"mult_dmg"
@@ -25714,15 +25715,30 @@ Weapon by: 'The One Of Wonders'"
 					"attribute_class"	"mult_clipsize"
 					"value"				"0.375"
 				}
-				"reload time increased"
+				"strange restriction type 1"
+				{
+					"attribute_class"	"chargeweapon_no_extra_speed"
+					"value"				"1"
+				}
+				"scattergun no reload single"
+				{
+					"attribute_class"		"set_scattergun_no_reload_single"
+					"value"					"1" 
+				}
+				"voice pitch scale"
 				{
 					"attribute_class"	"mult_reload_time"
-					"value"				"1.33"
+					"value"				"2"
 				}
 				"max pipebombs decreased"
 				{
 					"attribute_class"	"add_max_pipebombs"
 					"value" 			"-5"
+				}
+				"UNIQUE no stickybomb charge rate"
+				{
+					"attribute_class"	"stickybomb_charge_rate"
+					"value" 			"0.0"
 				}
 				"crit mod disabled"															
 				{
@@ -32185,6 +32201,14 @@ Sword pierces resistances."
 			"effect_type"	"positive"
 			"armory_Desc"	"on_active"
 			"stored_as_integer"	"0"
+		}
+		"30060"
+		{
+			"name"	"UNIQUE no stickybomb charge rate"
+			"attribute_class"	"stickybomb_charge_rate"
+			"description_format"	"value_is_inverted_percentage"
+			"description_string"	"No stickybomb charge"
+			"effect_type"	"negative"
 		}
 	}
 }


### PR DESCRIPTION
I never really understood what the purpose of this weapon is -- it deals bleed damage on an increased explosion radius which does suggest it is intended for crowd control, but its damage output is so lackluster and it doesn't introduce anything other stickybomb launchers don't already do better

It's hard to design new stickybomb launchers with the current attributes, however I noticed that there arent any of this type that can reload their clip all at once. Not having to think much about reloading is great, and you will be able to use the weapon at any time. It should take roughly the time to reload two stickies... 

To increase its effectiveness as a crowd control tool and to make up for the lack of damage, i propose increasing the fire rate a little from +10% to +25%, so setting up a single trap around a crowd is faster. 

These tweaks also double as a powerful deterrent for enemies in cases where the stock stickybomb launcher's slow fire rate can not keep up, and runs out of ammo due to its lengthy reload time. Given that, i think it's only fair to reduce its effective range by removing the charge mechanic entirely, i dont imagine it will be used all that often anyway

this probably doesnt really introduce anything totally unique or groundbreaking, but playing around with it i think it now deserves a place among the other secondaries

![image](https://github.com/Reagy/TF2Classic-KO-Custom-Weapons/assets/67557558/b9e43145-59a0-4bf0-9943-da417c83ff98)
